### PR TITLE
MSM8916: Gain more CPU frequency, overclock SSD/eMMC, fix temp stuff

### DIFF
--- a/arch/arm/boot/dts/samsung/msm8916/msm8916.dtsi
+++ b/arch/arm/boot/dts/samsung/msm8916/msm8916.dtsi
@@ -380,7 +380,7 @@
 			< 1363200000 9>,
 			< 1497600000 10>,
 			< 1728000000 11>,
-			< 1881600000 12>;
+			< 1900800000 12>;
 	};
 
 	cpubw: qcom,cpubw@0 {
@@ -414,7 +414,7 @@
 				 < 1094400  3051>,
 				 < 1248000  4066>,
 				 < 1497600  5088>,
-				 < 1881600  6102>;
+				 < 1900800  6102>;
 		};
 	};
 
@@ -439,7 +439,7 @@
 			 < 1363200 >,
 			 < 1497600 >,
 			 < 1728000 >,
-			 < 1881600 >;
+			 < 1900800 >;
 	};
 
 	qcom,sps {
@@ -694,7 +694,7 @@
 			 <&clock_gcc clk_gcc_sdcc1_apps_clk>;
 		clock-names = "iface_clk", "core_clk";
 
-		qcom,clk-rates = <400000 25000000 50000000 100000000 177770000>;
+		qcom,clk-rates = <400000 25000000 50000000 100000000 200000000>;
 		qcom,bus-speed-mode = "HS200_1p8v", "DDR_1p8v";
 
 		status = "disabled";
@@ -1489,7 +1489,7 @@
 		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
 			 <&clock_gcc clk_gcc_blsp1_qup2_i2c_apps_clk>;
 		clock-names = "iface_clk", "core_clk";
-		qcom,clk-freq-out = <100000>;
+		qcom,clk-freq-out = <400000>;
 		qcom,clk-freq-in  = <19200000>;
 		pinctrl-names = "i2c_active", "i2c_sleep";
 		pinctrl-0 = <&i2c_0_active>;
@@ -1510,7 +1510,7 @@
 		      <0x7884000 0x23000>;
 		interrupt-names = "qup_irq", "bam_irq";
 		interrupts = <0 95 0>, <0 238 0>;
-		qcom,clk-freq-out = <100000>;
+		qcom,clk-freq-out = <400000>;
 		qcom,clk-freq-in  = <19200000>;
 		clock-names = "iface_clk", "core_clk";
 		clocks = <&clock_gcc clk_gcc_blsp1_ahb_clk>,
@@ -1686,11 +1686,11 @@
 		qcom,core-limit-temp = <85>;
 		qcom,core-temp-hysteresis = <10>;
 		qcom,core-control-mask = <0xe>;
-		qcom,hotplug-temp = <105>;
+		qcom,hotplug-temp = <100>;
 		qcom,hotplug-temp-hysteresis = <15>;
 		qcom,cpu-sensors = "tsens_tz_sensor5", "tsens_tz_sensor5",
 				"tsens_tz_sensor4", "tsens_tz_sensor4";
-		qcom,freq-mitigation-temp = <105>;
+		qcom,freq-mitigation-temp = <100>;
 		qcom,freq-mitigation-temp-hysteresis = <15>;
 		qcom,freq-mitigation-value = <400000>;
 		qcom,freq-mitigation-control-mask = <0x01>;

--- a/drivers/clk/qcom/clock-gcc-8916.c
+++ b/drivers/clk/qcom/clock-gcc-8916.c
@@ -349,7 +349,7 @@ static struct pll_freq_tbl apcs_pll_freq[] = {
 	F_APCS_PLL(1363200000, 71, 0x0, 0x1, 0x0, 0x0, 0x0),
 	F_APCS_PLL(1497600000, 78, 0x0, 0x1, 0x0, 0x0, 0x0),
 	F_APCS_PLL(1728000000, 90, 0x0, 0x1, 0x0, 0x0, 0x0),
-	F_APCS_PLL(1881600000, 98, 0x0, 0x1, 0x0, 0x0, 0x0),
+	F_APCS_PLL(1900800000, 99, 0x0, 0x1, 0x0, 0x0, 0x0),
 	PLL_F_END
 };
 
@@ -1194,6 +1194,7 @@ static struct clk_freq_tbl ftbl_gcc_sdcc1_apps_clk[] = {
 	F(  50000000,	   gpll0,  16,	  0,	0),
 	F( 100000000,	   gpll0,   8,	  0,	0),
 	F( 177770000,	   gpll0, 4.5,	  0,	0),
+	F( 200000000,	   gpll0,   4,	  0,	0),
 	F_END
 };
 
@@ -1218,7 +1219,7 @@ static struct clk_freq_tbl ftbl_gcc_sdcc2_apps_clk[] = {
 	F(  25000000,	   gpll0,  16,	  1,	2),
 	F(  50000000,	   gpll0,  16,	  0,	0),
 	F( 100000000,	   gpll0,   8,	  0,	0),
-	F( 177770000,	   gpll0,   4.5,	  0,	0),
+	F( 177770000,	   gpll0, 4.5,	  0,	0),
 	F( 200000000,	   gpll0,   4,	  0,	0),
 	F_END
 };


### PR DESCRIPTION
Try to overclock CPU to max multiplier: 19,2×99=1900,8GHz
Overclock eMMC/SSD storage 177 to 200MHz (Maximum)