### PR TITLE
drivers: mmc: sysfs interface to Enable / Disable CRC 

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -74,9 +74,25 @@ static const unsigned freqs[] = { 400000, 300000, 200000, 100000 };
  * Enabling software CRCs on the data blocks can be a significant (30%)
  * performance cost, and for other reasons may not always be desired.
  * So we allow it it to be disabled.
+ * 
+ * SysFs interface :
+ *
+ * /sys/module/mmc_core/parameters/crc
+ *
+ * Enable / Disable CRC 
+ * 
+ * echo N > /sys/module/mmc_core/parameters/crc (Disabled) or
+ * echo 0 > /sys/module/mmc_core/parameters/crc (Disabled)
+ *
+ * echo Y > /sys/module/mmc_core/parameters/crc (Enlabled) or
+ * echo 1 > /sys/module/mmc_core/parameters/crc (Enabled)
  */
-bool use_spi_crc = 1;
-module_param(use_spi_crc, bool, 0);
+int use_spi_crc = 1;
+EXPORT_SYMBOL(use_spi_crc);
+module_param_named(crc, use_spi_crc, int, 0644);
+MODULE_PARM_DESC(
+	crc,
+	"Enable/disable CRC");
 
 /*
  * We normally treat cards as removed during suspend if they are not

--- a/drivers/mmc/core/core.h
+++ b/drivers/mmc/core/core.h
@@ -73,7 +73,7 @@ int mmc_attach_sd(struct mmc_host *host);
 int mmc_attach_sdio(struct mmc_host *host);
 
 /* Module parameters */
-extern bool use_spi_crc;
+extern int use_spi_crc;
 
 /* Debugfs information for hosts and cards */
 void mmc_add_host_debugfs(struct mmc_host *host);


### PR DESCRIPTION
Enabling software CRCs on the data blocks can be a significant (30%) performance cost, and for other reasons may not always be desired. CRC is a mechanism aiming to prevent data corruption when enabled (reduce the performance around 30%). So if you disable it (improve the performance) but your data can be corrupted. Use it at your risk.